### PR TITLE
Add secured api config

### DIFF
--- a/public/app.json
+++ b/public/app.json
@@ -5,7 +5,19 @@
         "uuid": "OpenfinPOC",
         "applicationIcon": "http://localhost:5555/favicon.ico",
         "autoShow": true,
-        "saveWindowState": true
+        "saveWindowState": true,
+        "permissions": {
+            "System": {
+               "downloadAsset": true,
+               "launchExternalProcess": true,
+               "readRegistryValue": true,
+               "terminateExternalProcess": true,
+               "getAllExternalWindows": true
+            },
+            "ExternalWindow": {
+                "wrap": true
+            }
+        }
     },
     "runtime": {
         "arguments": "",


### PR DESCRIPTION
Add config options to app manifest.

Let me know if it would make more sense to leave them out in the interest of maintaining a minimalist starter config. In my mind, it will make these APIs easier for users to explore.